### PR TITLE
fix: lazy load Vite config for server build

### DIFF
--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,14 +1,12 @@
 import express, { type Express } from "express";
 import fs from "fs";
 import path from "path";
-import { createServer as createViteServer, createLogger } from "vite";
 import { type Server } from "http";
-import viteConfig from "../vite.config";
 import { nanoid } from "nanoid";
 import { fileURLToPath } from "url";
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const viteLogger = createLogger();
 
 export function log(message: string, source = "express") {
   const formattedTime = new Date().toLocaleTimeString("en-US", {
@@ -22,6 +20,10 @@ export function log(message: string, source = "express") {
 }
 
 export async function setupVite(app: Express, server: Server) {
+  const { createServer: createViteServer, createLogger } = await import("vite");
+  const viteConfig = (await import(path.resolve(process.cwd(), "vite.config.ts"))).default;
+  const viteLogger = createLogger();
+
   const serverOptions = {
     middlewareMode: true,
     hmr: { server },


### PR DESCRIPTION
## Summary
- Defer Vite and config imports to runtime so production builds skip bundling dev-only plugins

## Testing
- `npm run build`
- `npx cross-env NODE_ENV=production esbuild server/index.ts --bundle --platform=node --target=node16 --format=esm --outdir=dist/server --external:*.css --external:*.png --external:@shared/* --external:lightningcss --external:*.node`


------
https://chatgpt.com/codex/tasks/task_e_689b4750020c833095e64d0272054ff1