### PR TITLE
fix: include shared modules in server build

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -1,0 +1,9 @@
+import app from "../server/index";
+
+export default app;
+
+export const config = {
+  runtime: "nodejs20.x",
+  includeFiles: ["dist/server/public/**"],
+};
+

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev:renderer": "vite --port 3000",
     "electron-dev": "concurrently -k -n SERVER,UI,APP -c cyan,magenta,yellow \"npm run dev:server\" \"npm run dev:renderer\" \"wait-on http://localhost:3000 && electron .\"",
     "electron": "electron .",
-    "build:server": "cross-env NODE_ENV=production esbuild server/index.ts --bundle --platform=node --target=node16 --format=esm --outdir=dist/server --external:*.css --external:*.png --external:@shared/* --external:lightningcss --external:*.node",
+    "build:server": "cross-env NODE_ENV=production esbuild server/index.ts --bundle --platform=node --target=node16 --format=esm --packages=external --outdir=dist/server --external:@babel/preset-typescript/package.json --external:*.css --external:*.png --external:lightningcss --external:*.node",
     "build:renderer": "vite build --config vite.config.ts",
     "build:electron": "npm run build:renderer && npm run build:server",
     "build": "npm run build:renderer && npm run build:server",
@@ -49,7 +49,6 @@
       "electron-main.js",
       "preload.js",
       "dist/**/*",
-      "server/public/**/*",
       "assets/**/*",
       "certs/**/*",
       "package.json"

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,5 +1,4 @@
 import type { Express } from "express";
-import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import { loadExercisesFromFiles } from "./services/exerciseParser";
 import { callGroqAPI } from "./services/groqApi";
@@ -77,7 +76,7 @@ function calculateBKTProgress(sectionId: number, exercises: any[]): number {
   return Math.min(95, Math.round((baseProgress + domainBonus) * difficultyMultiplier));
 }
 
-export async function registerRoutes(app: Express): Promise<Server> {
+export async function registerRoutes(app: Express): Promise<void> {
   // Initialize exercises on startup
   try {
     await loadExercisesFromFiles();
@@ -387,6 +386,4 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  const httpServer = createServer(app);
-  return httpServer;
 }

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -69,7 +69,7 @@ export async function setupVite(app: Express, server: Server) {
 }
 
 export function serveStatic(app: Express) {
-  const distPath = path.resolve(__dirname, "public");
+  const distPath = path.resolve(process.cwd(), "dist/server/public");
 
   if (!fs.existsSync(distPath)) {
     throw new Error(

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "routes": [
+    { "src": "/(.*)", "dest": "api/index.ts" }
+  ]
+}
+

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,7 +26,7 @@ export default defineConfig(async ({ mode }) => {
     },
     root: path.resolve(__dirname, "client"),
     build: {
-      outDir: path.resolve(__dirname, "server/public"),
+      outDir: path.resolve(__dirname, "dist/server/public"),
       emptyOutDir: true,
     },
     server: {


### PR DESCRIPTION
## Summary
- externalize dependencies while bundling server to retain local shared modules
- output client build to `dist/server/public` for better deployment compatibility
- export Express app and route traffic through a Vercel function

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b4750020c833095e64d0272054ff1