### PR TITLE
feat: adapt server for vercel

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -1,0 +1,3 @@
+import app from "../server/index";
+
+export default app;

--- a/client/src/components/SettingsModal.tsx
+++ b/client/src/components/SettingsModal.tsx
@@ -227,13 +227,14 @@ const handleSave = () => {
 const handleFileUpload = async () => {
   const fileInput = fileInputRef.current;
   const files = fileInput?.files ? Array.from(fileInput.files) : [];
+  const jsFiles = files.filter(f => f.name.endsWith('.js'));
 
-  if (files.length === 0) return;
+  if (jsFiles.length === 0) return;
 
   setUploading(true);
   try {
-    // 1) Sube todos los archivos al servidor
-    await uploadExerciseFiles(files);
+    // 1) Sube todos los archivos .js al servidor
+    await uploadExerciseFiles(jsFiles);
 
     // 2) Limpia los inputs de UI
     setMultiFileNames([]);
@@ -305,10 +306,11 @@ const [uploading, setUploading] = useState(false);
 // Handler para selección múltiple
 const handleBulkFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
   const files = e.target.files ? Array.from(e.target.files) : [];
-  // Guardamos sólo los nombres
-  setMultiFileNames(files.map(f => f.name));
+  const jsFiles = files.filter(f => f.name.endsWith('.js'));
+  // Guardamos los nombres o rutas relativas
+  setMultiFileNames(jsFiles.map(f => f.webkitRelativePath || f.name));
   // Leemos todos los contenidos en paralelo
-  const texts = await Promise.all(files.map(f => f.text()));
+  const texts = await Promise.all(jsFiles.map(f => f.text()));
   setMultiFileContents(texts);
 };
 
@@ -445,7 +447,7 @@ const getSectionName = (fileName?: string): string => {
               </ul>
 
               {/* El resto: formulario de subida… */}
-              {/* Upload Section (multi-file) */}
+              {/* Upload Section (folder) */}
               <div className="space-y-3">
                 <div className="flex items-center gap-2">
                   <Button
@@ -455,9 +457,11 @@ const getSectionName = (fileName?: string): string => {
                     className="bg-gray-800 border-gray-600 text-gray-200 hover:bg-gray-700"
                   >
                     <Upload className="h-4 w-4 mr-1" />
-                    Seleccionar archivos
+                    Cargar carpeta
                   </Button>
-                  <span className="text-xs text-gray-500">Solo archivos .js</span>
+                  <span className="text-xs text-gray-500">
+                    Se cargarán los archivos .js de la carpeta
+                  </span>
                   <input
                     ref={fileInputRef}
                     type="file"
@@ -465,6 +469,7 @@ const getSectionName = (fileName?: string): string => {
                     multiple
                     onChange={handleBulkFileChange}
                     className="hidden"
+                    {...({ webkitdirectory: true } as any)}
                   />
                 </div>
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev:renderer": "vite --port 3000",
     "electron-dev": "concurrently -k -n SERVER,UI,APP -c cyan,magenta,yellow \"npm run dev:server\" \"npm run dev:renderer\" \"wait-on http://localhost:3000 && electron .\"",
     "electron": "electron .",
-    "build:server": "cross-env NODE_ENV=production esbuild server/index.ts --bundle --platform=node --target=node16 --format=esm --outdir=dist/server --external:*.css --external:*.png --external:@shared/* --external:lightningcss --external:*.node",
+    "build:server": "cross-env NODE_ENV=production esbuild server/index.ts --bundle --platform=node --target=node16 --format=esm --packages=external --outdir=dist/server --external:@babel/preset-typescript/package.json --external:*.css --external:*.png --external:lightningcss --external:*.node",
     "build:renderer": "vite build --config vite.config.ts",
     "build:electron": "npm run build:renderer && npm run build:server",
     "build": "npm run build:renderer && npm run build:server",
@@ -49,7 +49,6 @@
       "electron-main.js",
       "preload.js",
       "dist/**/*",
-      "server/public/**/*",
       "assets/**/*",
       "certs/**/*",
       "package.json"

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,7 +1,6 @@
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
-import { setupVite, serveStatic, log } from "./vite";
-import { spawn } from "child_process";
+import { serveStatic } from "./static";
 
 const app = express();
 app.use(express.json());
@@ -35,27 +34,40 @@ app.use((req: Request, res: Response, next: NextFunction) => {
   next();
 });
 
-(async () => {
-  const isDev = process.env.NODE_ENV === 'development';
-  const port = 5000;
+export default app;
 
-  // Registrar rutas y manejar errores
-  const server = await registerRoutes(app);
+function log(message: string, source = "express") {
+  const formattedTime = new Date().toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: true,
+  });
+  console.log(`${formattedTime} [${source}] ${message}`);
+}
+
+const isVercel = Boolean(process.env.VERCEL);
+const isDev = process.env.NODE_ENV === "development";
+const port = process.env.PORT ? Number(process.env.PORT) : 5000;
+
+async function start() {
+  await registerRoutes(app);
   app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
     const status = err.status || err.statusCode || 500;
-    const message = err.message || 'Internal Server Error';
+    const message = err.message || "Internal Server Error";
     res.status(status).json({ message });
     throw err;
   });
 
-  // Configurar Vite en dev o servir estáticos en producción
-  if (isDev) {
-    await setupVite(app, server);
-  } else {
+  if (!isVercel && !isDev) {
     serveStatic(app);
   }
 
-  server.listen({ port }, () => {
-    log(`serving on port ${port}`);
-  });    // <— cierra server.listen
-})();   // <— cierra y ejecuta el IIFE
+  if (!isVercel) {
+    app.listen(port, () => {
+      log(`serving on port ${port}`);
+    });
+  }
+}
+
+start();

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,5 +1,4 @@
 import type { Express } from "express";
-import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import { loadExercisesFromFiles } from "./services/exerciseParser";
 import { callGroqAPI } from "./services/groqApi";
@@ -77,7 +76,7 @@ function calculateBKTProgress(sectionId: number, exercises: any[]): number {
   return Math.min(95, Math.round((baseProgress + domainBonus) * difficultyMultiplier));
 }
 
-export async function registerRoutes(app: Express): Promise<Server> {
+export async function registerRoutes(app: Express): Promise<void> {
   // Initialize exercises on startup
   try {
     await loadExercisesFromFiles();
@@ -387,6 +386,4 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  const httpServer = createServer(app);
-  return httpServer;
 }

--- a/server/static.ts
+++ b/server/static.ts
@@ -1,0 +1,18 @@
+import express, { type Express } from "express";
+import fs from "fs";
+import path from "path";
+
+export function serveStatic(app: Express) {
+  const distPath = path.resolve(__dirname, "public");
+
+  if (!fs.existsSync(distPath)) {
+    throw new Error(
+      `Could not find the build directory: ${distPath}, make sure to build the client first`,
+    );
+  }
+
+  app.use(express.static(distPath));
+  app.use("*", (_req, res) => {
+    res.sendFile(path.resolve(distPath, "index.html"));
+  });
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["client/src/**/*", "shared/**/*", "server/**/*"],
+  "include": ["client/src/**/*", "shared/**/*", "server/**/*", "api/**/*"],
   "exclude": ["node_modules", "build", "dist", "**/*.test.ts"],
   "compilerOptions": {
     "incremental": true,

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist/server/public",
+  "routes": [
+    { "src": "/api/(.*)", "dest": "/api/index.ts" },
+    { "handle": "filesystem" },
+    { "src": "/(.*)", "dest": "/index.html" }
+  ]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,7 +26,7 @@ export default defineConfig(async ({ mode }) => {
     },
     root: path.resolve(__dirname, "client"),
     build: {
-      outDir: path.resolve(__dirname, "server/public"),
+      outDir: path.resolve(__dirname, "dist/server/public"),
       emptyOutDir: true,
     },
     server: {


### PR DESCRIPTION
## Summary
- expose express app without listening so it can run as a Vercel function
- serve built client files from a dedicated helper and wire up API entry point
- add Vercel routing config and include the new API folder in TypeScript settings
- allow uploading a local folder of JavaScript files instead of selecting individual files

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b4750020c833095e64d0272054ff1