### PR TITLE
feat: adapt server for vercel

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -1,0 +1,3 @@
+import app from "../server/index";
+
+export default app;

--- a/client/dist/public/index.html
+++ b/client/dist/public/index.html
@@ -7,7 +7,6 @@
     <meta name="description" content="Interfaz ultra-minimalista para estudiar matemáticas con ejercicios dinámicos, timer Pomodoro y respuestas automáticas.">
     
     <!-- Math rendering -->
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">

--- a/client/dist/renderer/index.html
+++ b/client/dist/renderer/index.html
@@ -7,7 +7,6 @@
     <meta name="description" content="Interfaz ultra-minimalista para estudiar matemáticas con ejercicios dinámicos, timer Pomodoro y respuestas automáticas.">
     
     <!-- Math rendering -->
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">

--- a/client/index.html
+++ b/client/index.html
@@ -7,7 +7,6 @@
     <meta name="description" content="Interfaz ultra-minimalista para estudiar matemáticas con ejercicios dinámicos, timer Pomodoro y respuestas automáticas.">
     
     <!-- Math rendering -->
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">

--- a/client/server/public/index.html
+++ b/client/server/public/index.html
@@ -7,7 +7,6 @@
     <meta name="description" content="Interfaz ultra-minimalista para estudiar matemáticas con ejercicios dinámicos, timer Pomodoro y respuestas automáticas.">
     
     <!-- Math rendering -->
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">

--- a/client/src/components/SettingsModal.tsx
+++ b/client/src/components/SettingsModal.tsx
@@ -302,13 +302,14 @@ const [multiFileNames, setMultiFileNames] = useState<string[]>([]);
 const [multiFileContents, setMultiFileContents] = useState<string[]>([]);
 const [uploading, setUploading] = useState(false);
 
-// Handler para selección múltiple
+// Handler para selección de carpeta
 const handleBulkFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
   const files = e.target.files ? Array.from(e.target.files) : [];
-  // Guardamos sólo los nombres
-  setMultiFileNames(files.map(f => f.name));
+  const jsFiles = files.filter(f => f.name.endsWith('.js'));
+  // Guardamos sólo los nombres de archivos .js
+  setMultiFileNames(jsFiles.map(f => f.name));
   // Leemos todos los contenidos en paralelo
-  const texts = await Promise.all(files.map(f => f.text()));
+  const texts = await Promise.all(jsFiles.map(f => f.text()));
   setMultiFileContents(texts);
 };
 
@@ -455,16 +456,17 @@ const getSectionName = (fileName?: string): string => {
                     className="bg-gray-800 border-gray-600 text-gray-200 hover:bg-gray-700"
                   >
                     <Upload className="h-4 w-4 mr-1" />
-                    Seleccionar archivos
+                    Cargar carpeta
                   </Button>
-                  <span className="text-xs text-gray-500">Solo archivos .js</span>
+                  <span className="text-xs text-gray-500">Usará los archivos .js de la carpeta seleccionada</span>
                   <input
                     ref={fileInputRef}
                     type="file"
-                    accept=".js"
                     multiple
                     onChange={handleBulkFileChange}
                     className="hidden"
+                    directory=""
+                    webkitdirectory=""
                   />
                 </div>
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev:renderer": "vite --port 3000",
     "electron-dev": "concurrently -k -n SERVER,UI,APP -c cyan,magenta,yellow \"npm run dev:server\" \"npm run dev:renderer\" \"wait-on http://localhost:3000 && electron .\"",
     "electron": "electron .",
-    "build:server": "cross-env NODE_ENV=production esbuild server/index.ts --bundle --platform=node --target=node16 --format=esm --outdir=dist/server --external:*.css --external:*.png --external:@shared/* --external:lightningcss --external:*.node",
+    "build:server": "cross-env NODE_ENV=production esbuild server/index.ts --bundle --platform=node --target=node16 --format=esm --packages=external --outdir=dist/server --external:@babel/preset-typescript/package.json --external:*.css --external:*.png --external:lightningcss --external:*.node",
     "build:renderer": "vite build --config vite.config.ts",
     "build:electron": "npm run build:renderer && npm run build:server",
     "build": "npm run build:renderer && npm run build:server",
@@ -49,7 +49,6 @@
       "electron-main.js",
       "preload.js",
       "dist/**/*",
-      "server/public/**/*",
       "assets/**/*",
       "certs/**/*",
       "package.json"

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,7 +1,6 @@
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
-import { setupVite, serveStatic, log } from "./vite";
-import { spawn } from "child_process";
+import { serveStatic } from "./static";
 
 const app = express();
 app.use(express.json());
@@ -35,27 +34,40 @@ app.use((req: Request, res: Response, next: NextFunction) => {
   next();
 });
 
-(async () => {
-  const isDev = process.env.NODE_ENV === 'development';
-  const port = 5000;
+export default app;
 
-  // Registrar rutas y manejar errores
-  const server = await registerRoutes(app);
+function log(message: string, source = "express") {
+  const formattedTime = new Date().toLocaleTimeString("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: true,
+  });
+  console.log(`${formattedTime} [${source}] ${message}`);
+}
+
+const isVercel = Boolean(process.env.VERCEL);
+const isDev = process.env.NODE_ENV === "development";
+const port = process.env.PORT ? Number(process.env.PORT) : 5000;
+
+async function start() {
+  await registerRoutes(app);
   app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
     const status = err.status || err.statusCode || 500;
-    const message = err.message || 'Internal Server Error';
+    const message = err.message || "Internal Server Error";
     res.status(status).json({ message });
     throw err;
   });
 
-  // Configurar Vite en dev o servir estáticos en producción
-  if (isDev) {
-    await setupVite(app, server);
-  } else {
+  if (!isVercel && !isDev) {
     serveStatic(app);
   }
 
-  server.listen({ port }, () => {
-    log(`serving on port ${port}`);
-  });    // <— cierra server.listen
-})();   // <— cierra y ejecuta el IIFE
+  if (!isVercel) {
+    app.listen(port, () => {
+      log(`serving on port ${port}`);
+    });
+  }
+}
+
+start();

--- a/server/public/index.html
+++ b/server/public/index.html
@@ -7,7 +7,6 @@
     <meta name="description" content="Interfaz ultra-minimalista para estudiar matemáticas con ejercicios dinámicos, timer Pomodoro y respuestas automáticas.">
     
     <!-- Math rendering -->
-    <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
     <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css">

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,7 +1,6 @@
 import type { Express } from "express";
-import { createServer, type Server } from "http";
 import { storage } from "./storage";
-import { loadExercisesFromFiles } from "./services/exerciseParser";
+import { loadExercisesFromFiles, addExercisesFromContent, getUploadedFilenames, removeUploadedFile } from "./services/exerciseParser";
 import { callGroqAPI } from "./services/groqApi";
 import { insertResponseSchema, insertSettingsSchema } from "@shared/schema";
 import { logger } from "./logger";
@@ -77,7 +76,7 @@ function calculateBKTProgress(sectionId: number, exercises: any[]): number {
   return Math.min(95, Math.round((baseProgress + domainBonus) * difficultyMultiplier));
 }
 
-export async function registerRoutes(app: Express): Promise<Server> {
+export async function registerRoutes(app: Express): Promise<void> {
   // Initialize exercises on startup
   try {
     await loadExercisesFromFiles();
@@ -294,23 +293,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   // Get list of uploaded section files
-  app.get("/api/sections/files", async (req, res) => {
+  app.get("/api/sections/files", (_req, res) => {
     try {
-      const fs = await import('fs/promises');
-      const path = await import('path');
-      
-      const subeSeccionPath = path.join(process.cwd(), 'sube-seccion');
-      
-      try {
-        await fs.access(subeSeccionPath);
-      } catch {
-        return res.json([]);
-      }
-      
-      const files = await fs.readdir(subeSeccionPath);
-      const jsFiles = files.filter(file => file.endsWith('.js'));
-      
-      res.json(jsFiles);
+      res.json(getUploadedFilenames());
     } catch (error) {
       console.error('Error reading section files:', error);
       res.status(500).json({ error: 'Failed to read section files' });
@@ -320,34 +305,18 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Upload new section file
   app.post("/api/sections/upload", async (req, res) => {
     try {
-      const fs = await import('fs/promises');
-      const path = await import('path');
-      
       const { filename, content } = req.body;
-      
+
       if (!filename || !content) {
         return res.status(400).json({ error: 'Filename and content are required' });
       }
-      
+
       if (!filename.endsWith('.js')) {
         return res.status(400).json({ error: 'Only .js files are allowed' });
       }
-      
-      const subeSeccionPath = path.join(process.cwd(), 'sube-seccion');
-      
-      // Create directory if it doesn't exist
-      try {
-        await fs.access(subeSeccionPath);
-      } catch {
-        await fs.mkdir(subeSeccionPath, { recursive: true });
-      }
-      
-      const filePath = path.join(subeSeccionPath, filename);
-      await fs.writeFile(filePath, content, 'utf8');
-      
-      // Reload exercises
-      await loadExercisesFromFiles();
-      
+
+      await addExercisesFromContent(filename, content);
+
       res.json({ success: true, message: 'File uploaded successfully' });
     } catch (error) {
       console.error('Error uploading section file:', error);
@@ -358,35 +327,20 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // Delete section file
   app.delete("/api/sections/files/:filename", async (req, res) => {
     try {
-      const fs = await import('fs/promises');
-      const path = await import('path');
-      
       const filename = req.params.filename;
-      
+
       if (!filename.endsWith('.js')) {
         return res.status(400).json({ error: 'Only .js files can be deleted' });
       }
-      
-      const subeSeccionPath = path.join(process.cwd(), 'sube-seccion');
-      const filePath = path.join(subeSeccionPath, filename);
-      
-      try {
-        await fs.access(filePath);
-        await fs.unlink(filePath);
-        
-        // Reload exercises
-        await loadExercisesFromFiles();
-        
-        res.json({ success: true, message: 'File deleted successfully' });
-      } catch (error) {
-        res.status(404).json({ error: 'File not found' });
-      }
+
+      removeUploadedFile(filename);
+      await loadExercisesFromFiles();
+
+      res.json({ success: true, message: 'File deleted successfully' });
     } catch (error) {
       console.error('Error deleting section file:', error);
       res.status(500).json({ error: 'Failed to delete section file' });
     }
   });
 
-  const httpServer = createServer(app);
-  return httpServer;
 }

--- a/server/services/exerciseParser.ts
+++ b/server/services/exerciseParser.ts
@@ -3,6 +3,32 @@ import { type InsertExercise } from "@shared/schema";
 import { promises as fs } from 'fs';
 import { join } from 'path';
 
+const memoryUploads: { filename: string; exercises: RawExercise[] }[] = [];
+
+export function getUploadedFilenames(): string[] {
+  return memoryUploads.map(u => u.filename);
+}
+
+export function removeUploadedFile(filename: string): void {
+  const index = memoryUploads.findIndex(u => u.filename === filename);
+  if (index !== -1) memoryUploads.splice(index, 1);
+}
+
+export async function addExercisesFromContent(filename: string, content: string): Promise<void> {
+  const fileUrl = `data:text/javascript;base64,${Buffer.from(content).toString('base64')}`;
+  const module = await import(fileUrl);
+  if (module.ejercicios && Array.isArray(module.ejercicios)) {
+    const sectionName = `Seccion ${memoryUploads.length + 4}`;
+    const sectionExercises = module.ejercicios.map((ex: RawExercise) => ({
+      ...ex,
+      seccion: sectionName,
+      _sourceFile: filename
+    }));
+    memoryUploads.push({ filename, exercises: sectionExercises });
+    await loadExercisesFromFiles();
+  }
+}
+
 interface RawExercise {
   seccion?: string;
   tema: string;
@@ -31,13 +57,15 @@ export async function loadExercisesFromFiles(): Promise<void> {
     
     // 2) Load from sube-seccion folder (dynamic uploads)
     await loadFromSubeSeccion(allRawExercises);
-    
-    // 3) Process and organize exercises
+
+    // 3) Load from in-memory uploads
+    loadFromMemoryUploads(allRawExercises);
+    // 4) Process and organize exercises
     const processedExercises = processExercises(allRawExercises);
-    
-    // 4) Store in memory
+
+    // 5) Store in memory
     await storage.createExercises(processedExercises);
-    
+
     const maxSection = Math.max(...processedExercises.map(ex => ex.sectionId));
     console.log(`Loaded ${processedExercises.length} exercises across ${maxSection} sections`);
   } catch (error) {
@@ -101,6 +129,12 @@ async function loadFromSubeSeccion(allRawExercises: RawExercise[]): Promise<void
     }
   } catch (error) {
     console.error("Error accessing sube-seccion folder:", error);
+  }
+}
+
+function loadFromMemoryUploads(allRawExercises: RawExercise[]): void {
+  for (const upload of memoryUploads) {
+    allRawExercises.push(...upload.exercises);
   }
 }
 

--- a/server/static.ts
+++ b/server/static.ts
@@ -1,0 +1,18 @@
+import express, { type Express } from "express";
+import fs from "fs";
+import path from "path";
+
+export function serveStatic(app: Express) {
+  const distPath = path.resolve(__dirname, "public");
+
+  if (!fs.existsSync(distPath)) {
+    throw new Error(
+      `Could not find the build directory: ${distPath}, make sure to build the client first`,
+    );
+  }
+
+  app.use(express.static(distPath));
+  app.use("*", (_req, res) => {
+    res.sendFile(path.resolve(distPath, "index.html"));
+  });
+}

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -265,4 +265,13 @@ class FileStorage extends MemStorage {
   }
 }
 
-export const storage = new FileStorage();
+const dataDir = process.env.VERCEL ? '/tmp/ejes' : '/gestor/system/ejes';
+
+export const storage: IStorage = (() => {
+  try {
+    return new FileStorage(dataDir);
+  } catch (err) {
+    console.warn('Falling back to in-memory storage:', err);
+    return new MemStorage();
+  }
+})();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["client/src/**/*", "shared/**/*", "server/**/*"],
+  "include": ["client/src/**/*", "shared/**/*", "server/**/*", "api/**/*"],
   "exclude": ["node_modules", "build", "dist", "**/*.test.ts"],
   "compilerOptions": {
     "incremental": true,

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist/server/public",
+  "routes": [
+    { "src": "/api/(.*)", "dest": "/api/index.ts" },
+    { "handle": "filesystem" },
+    { "src": "/(.*)", "dest": "/index.html" }
+  ]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,7 +26,7 @@ export default defineConfig(async ({ mode }) => {
     },
     root: path.resolve(__dirname, "client"),
     build: {
-      outDir: path.resolve(__dirname, "server/public"),
+      outDir: path.resolve(__dirname, "dist/server/public"),
       emptyOutDir: true,
     },
     server: {


### PR DESCRIPTION
## Summary
- remove external polyfill script from bundled HTML to avoid DNS lookup failures
- use Vercel's `/tmp` directory for storage with an in-memory fallback to prevent API 500s

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689b4750020c833095e64d0272054ff1