### PR TITLE
Load section files locally

### DIFF
--- a/client/src/components/SettingsModal.tsx
+++ b/client/src/components/SettingsModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { useAppStore } from '@/store/useAppStore';
 import { apiRequest } from '@/lib/queryClient';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
@@ -12,7 +12,6 @@ import { Trash2, Upload, FileText, Plus,FileDown, FileUp, X, Save  } from 'lucid
 import type { Settings } from '@shared/schema';
 
 export function SettingsModal() {
-  const queryClient = useQueryClient();
   const {
     isSettingsOpen,
     toggleSettings,
@@ -24,6 +23,10 @@ export function SettingsModal() {
     resetTimer,
     loadExercises,
     uploadExerciseFiles,
+    sectionFiles,
+    setSectionFiles,
+    removeSectionFile,
+    setExercises,
   } = useAppStore();
 
   const clearAll = useAppStore(state => state.clearAllResponses);
@@ -99,76 +102,8 @@ const updateSettingsMutation = useMutation({
       return response.json();
     },
   });
-// Section files queries and mutations
-const { data: sectionFiles = [] } = useQuery<string[]>({
-  queryKey: ['/api/sections/files'],
-  enabled: showSectionManager,
-});
 
-
-
-// — NUEVO: query para ejercicios dinámicos —
-const {
-  data: exercisesList = [],
-  refetch: refetchExercises,
-} = useQuery({
-  queryKey: ['/api/exercises'],
-  queryFn: () => fetch('/api/exercises').then(res => res.json()),
-  enabled: showSectionManager,
-});
-
-const uploadFileMutation = useMutation({
-  mutationFn: async ({ filename, content }: { filename: string; content: string }) => {
-    const response = await apiRequest('POST', '/api/sections/upload', { filename, content });
-    return response.json();
-  },
-  onSuccess: async () => {
-    // 1) invalidamos las queries
-    await queryClient.invalidateQueries({ queryKey: ['/api/sections/files'] });
-    await queryClient.invalidateQueries({ queryKey: ['/api/exercises'] });
-    await queryClient.invalidateQueries({ queryKey: ['/api/bkt/domains'] });
-
-    // 2) forzamos refetch inmediato
-    await queryClient.refetchQueries({ queryKey: ['/api/sections/files'] });
-    await queryClient.refetchQueries({ queryKey: ['/api/exercises'] });
-
-    // 3) refetch explícito para forzar propagación inmediata
-    await refetchExercises();
-
-    // 4) limpiamos el form de upload
-    setNewFileName('');
-    setNewFileContent('');
-    if (fileInputRef.current) {
-      fileInputRef.current.value = '';
-    }
-  },
-});
-
-const deleteFileMutation = useMutation({
-  mutationFn: async (filename: string) => {
-    const response = await apiRequest(
-      'DELETE',
-      `/api/sections/files/${encodeURIComponent(filename)}`
-    );
-    return response.json();
-  },
-  onSuccess: async () => { // ← debes marcar esto como async
-    // 1) refrescamos la lista de archivos y ejercicios
-    await queryClient.invalidateQueries({ queryKey: ['/api/sections/files'] });
-    await queryClient.invalidateQueries({ queryKey: ['/api/exercises'] });
-    await queryClient.invalidateQueries({ queryKey: ['/api/bkt/domains'] });
-
-    // 2) además disparamos el refetch explícito
-    await refetchExercises();
-
-    // 3) limpiamos el form de upload
-    setNewFileName('');
-    setNewFileContent('');
-    if (fileInputRef.current) {
-      fileInputRef.current.value = '';
-    }
-  },
-});
+// Section files are handled entirely on the client; no server mutations are needed.
 
 
 
@@ -232,29 +167,12 @@ const handleFileUpload = async () => {
 
   setUploading(true);
   try {
-    // 1) Sube todos los archivos al servidor
     await uploadExerciseFiles(files);
-
-    // 2) Limpia los inputs de UI
     setMultiFileNames([]);
     setMultiFileContents([]);
     if (fileInput) fileInput.value = '';
-
-    // 3) Invalida los caches de React Query
-    await queryClient.invalidateQueries({ queryKey: ['/api/sections/files'] });
-    await queryClient.invalidateQueries({ queryKey: ['/api/exercises'] });
-    await queryClient.invalidateQueries({ queryKey: ['/api/bkt/domains'] });
-
-    // 4) Fuerza refetch inmediato
-    await refetchSectionFiles();
-    await refetchExercises();
-
-    // 5) (Opcional) Re-aplica la sección actual en el store
-    // setCurrentSection(formData.currentSection);
-
   } catch (err) {
-    console.error("Error al subir archivos:", err);
-    // aquí podrías mostrar un toast de error
+    console.error("Error al cargar archivos:", err);
   } finally {
     setUploading(false);
   }
@@ -265,7 +183,7 @@ const handleFileUpload = async () => {
   // Handle file deletion
   const handleFileDelete = (filename: string) => {
     if (confirm(`¿Estás seguro de que quieres eliminar el archivo ${filename}?`)) {
-      deleteFileMutation.mutate(filename);
+      removeSectionFile(filename);
     }
   };
 
@@ -291,10 +209,8 @@ const handleDeleteAllFiles = () => {
     return;
   }
 
-  // Ejecutar la mutación para cada archivo
-  sectionFiles.forEach((filename) => {
-    deleteFileMutation.mutate(filename);
-  });
+  setSectionFiles([]);
+  setExercises([]);
 };
 
 // Estados para múltiples archivos
@@ -317,7 +233,7 @@ const handleBulkFileChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
 // Calcula dinámicamente las secciones según el nombre del fichero
 // Calcula dinámicamente las secciones según el nombre del fichero
 const sectionFileNames = Array.from(
-  new Set(exercises.map(ex => ex.fileName))
+  new Set(exercises.map(ex => (ex as any).fileName))
 ).sort();
 // A partir de los nombres de fichero, crea las opciones
 const sectionOptions = sectionFileNames.map(name => ({


### PR DESCRIPTION
## Summary
- load selected .js files directly in the browser and update exercises without server calls
- manage section file list client-side and allow deleting local sections

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689b90f487448330b00012ac6dbf6c95