### PR TITLE
Add improvement switch and server save

### DIFF
--- a/client/src/pages/StudyInterface.tsx
+++ b/client/src/pages/StudyInterface.tsx
@@ -11,6 +11,7 @@ import { BKTProgress } from '@/components/BKTProgress';
 import type { Exercise, Settings as SettingsType } from '@shared/schema';
 import { MathRenderer } from '@/components/MathRenderer';
 import { ExerciseFeedbackButton } from '@/components/ExerciseFeedbackButton';
+import { Switch } from '@/components/ui/switch';
 export default function StudyInterface() {
   const {
     setExercises,
@@ -35,6 +36,8 @@ export default function StudyInterface() {
     autoSaveStatus,
     settings: appSettings,
     lastCursorPos, setLastCursorPos,
+    improveMarks,
+    toggleImprove,
   } = useAppStore();
   // Ref para el textarea
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -136,6 +139,12 @@ export default function StudyInterface() {
         .getElementById(`feedback-btn-${currentExercise?.id}`)
         ?.click();
     }
+      if (e.ctrlKey && e.key.toLowerCase() === 'm') {
+        e.preventDefault();
+        if (currentExercise) {
+          toggleImprove(currentExercise);
+        }
+      }
 
     };
     document.addEventListener('keydown', handleKeyDown);
@@ -148,6 +157,7 @@ export default function StudyInterface() {
     nextExercise,
     saveCurrentResponse, // importante incluirla como dependencia
     currentExercise,
+    toggleImprove,
   ]);
 
 
@@ -309,6 +319,15 @@ export default function StudyInterface() {
       />
       )}
     </div>
+    {currentExercise && (
+      <div className="fixed bottom-4 right-4 flex items-center space-x-2">
+        <span className="text-xs text-gray-400">Mejorar</span>
+        <Switch
+          checked={!!improveMarks[currentExercise.id]}
+          onCheckedChange={() => toggleImprove(currentExercise)}
+        />
+      </div>
+    )}
       {/* Bottom Shortcuts */}
       <div className="text-center p-2 text-xs text-gray-600 border-t border-gray-800">
         Ctrl+← Anterior • Ctrl+→ Siguiente • Esc Configuración

--- a/client/src/store/useAppStore.ts
+++ b/client/src/store/useAppStore.ts
@@ -19,6 +19,8 @@ interface AppState {
   responses: Record<number, string>; // exerciseId -> response
   // Mapa exerciseId → posición de cursor dentro del textarea
   lastCursorPos: Record<number, number>;
+  // Ejercicios marcados para mejorar
+  improveMarks: Record<number, boolean>;
   // Acción para actualizar el mapa completo de posiciones
   setLastCursorPos: (positions: Record<number, number>) => void;
   uploadExerciseFiles: (files: File[]) => Promise<void>
@@ -61,6 +63,8 @@ interface AppState {
   loadResponse: (exerciseId: number) => string;
   nextExercise: () => void;
   previousExercise: () => void;
+  // Marcar ejercicio para mejorar
+  toggleImprove: (exercise: Exercise) => void;
 
   // Timer actions
   startTimer: () => void;
@@ -99,6 +103,7 @@ export const useAppStore = create<AppState>()(
       responses: {},
       // Inicialmente no hay posiciones de cursor guardadas:
       lastCursorPos: {},
+      improveMarks: {},
 
       // Setter: reemplaza el mapa completo
       setLastCursorPos: (positions: Record<number, number>) => {
@@ -322,7 +327,25 @@ clearAllResponses: () => {
           });
         }
       },
-
+      
+      toggleImprove: (exercise) => {
+        set(state => {
+          const isOn = !state.improveMarks[exercise.id];
+          const marks = { ...state.improveMarks, [exercise.id]: isOn };
+          if (isOn) {
+            fetch('/api/mejorar', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                tema: exercise.tema,
+                enunciado: exercise.enunciado,
+                ejercicio: exercise.ejercicio,
+              })
+            }).catch(() => {});
+          }
+          return { improveMarks: marks };
+        });
+      },
 
 
       // Timer actions

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -4,6 +4,8 @@ import { loadExercisesFromFiles, addExercisesFromContent, getUploadedFilenames, 
 import { callGroqAPI } from "./services/groqApi";
 import { insertResponseSchema, insertSettingsSchema } from "@shared/schema";
 import { logger } from "./logger";
+import { promises as fs } from 'fs';
+import { join } from 'path';
 
 // BKT helper functions
 function determineSectionDomain(topics: string[], exercises: any[]): string {
@@ -214,6 +216,36 @@ export async function registerRoutes(app: Express): Promise<void> {
     } catch (error) {
       console.error('Error fetching BKT domains:', error);
       res.status(500).json({ error: 'Failed to fetch BKT data' });
+    }
+  });
+
+  // Guardar ejercicios marcados para mejorar
+  app.post('/api/mejorar', async (req, res) => {
+    try {
+      const { tema, enunciado, ejercicio } = req.body;
+      if (!tema || !enunciado) {
+        return res.status(400).json({ error: 'Missing fields' });
+      }
+      const dir = join(process.cwd(), 'sube-seccion');
+      await fs.mkdir(dir, { recursive: true });
+      const filePath = join(dir, 'mejorar.js');
+      let ejercicios: any[] = [];
+      try {
+        const fileUrl = new URL(`file://${filePath}?update=${Date.now()}`);
+        const module = await import(fileUrl.href);
+        if (Array.isArray((module as any).ejercicios)) {
+          ejercicios = module.ejercicios as any[];
+        }
+      } catch {
+        // file might not exist yet
+      }
+      ejercicios.push({ tema, enunciado, ejercicio });
+      const content = `export const ejercicios = ${JSON.stringify(ejercicios, null, 2)};\n`;
+      await fs.writeFile(filePath, content, 'utf-8');
+      res.json({ success: true });
+    } catch (error) {
+      console.error('Error saving mejorar file:', error);
+      res.status(500).json({ error: 'Failed to save file' });
     }
   });
 


### PR DESCRIPTION
## Summary
- allow marking exercises with a new bottom-right toggle or Ctrl+M
- persist marked exercises to `sube-seccion/mejorar.js` via new API route
- track marked exercises in app state

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_689b9d73feb083308f93de23727cb4d9