### PR TITLE
Add manual mejoras saving and shortcut

### DIFF
--- a/client/src/pages/StudyInterface.tsx
+++ b/client/src/pages/StudyInterface.tsx
@@ -38,6 +38,7 @@ export default function StudyInterface() {
     lastCursorPos, setLastCursorPos,
     improveMarks,
     toggleImprove,
+    forceImprove,
   } = useAppStore();
   // Ref para el textarea
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -145,6 +146,12 @@ export default function StudyInterface() {
           toggleImprove(currentExercise);
         }
       }
+      if (e.ctrlKey && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        if (currentExercise) {
+          forceImprove(currentExercise);
+        }
+      }
 
     };
     document.addEventListener('keydown', handleKeyDown);
@@ -158,6 +165,7 @@ export default function StudyInterface() {
     saveCurrentResponse, // importante incluirla como dependencia
     currentExercise,
     toggleImprove,
+    forceImprove,
   ]);
 
 

--- a/client/src/store/useAppStore.ts
+++ b/client/src/store/useAppStore.ts
@@ -65,6 +65,7 @@ interface AppState {
   previousExercise: () => void;
   // Marcar ejercicio para mejorar
   toggleImprove: (exercise: Exercise) => void;
+  forceImprove: (exercise: Exercise) => void;
 
   // Timer actions
   startTimer: () => void;
@@ -343,6 +344,22 @@ clearAllResponses: () => {
               })
             }).catch(() => {});
           }
+          return { improveMarks: marks };
+        });
+      },
+
+      forceImprove: (exercise) => {
+        set(state => {
+          const marks = { ...state.improveMarks, [exercise.id]: true };
+          fetch('/api/mejorar', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              tema: exercise.tema,
+              enunciado: exercise.enunciado,
+              ejercicio: exercise.ejercicio,
+            })
+          }).catch(() => {});
           return { improveMarks: marks };
         });
       },

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -227,8 +227,8 @@ export async function registerRoutes(app: Express): Promise<void> {
         return res.status(400).json({ error: 'Missing fields' });
       }
       const dir = join(process.cwd(), 'sube-seccion');
-      await fs.mkdir(dir, { recursive: true });
-      const filePath = join(dir, 'mejorar.js');
+      await fs.mkdir(dir, { recursive: true, mode: 0o777 });
+      const filePath = join(dir, 'mejoras.js');
       let ejercicios: any[] = [];
 
       try {
@@ -243,10 +243,10 @@ export async function registerRoutes(app: Express): Promise<void> {
 
       ejercicios.push({ tema, enunciado, ejercicio });
       const content = `export const ejercicios = ${JSON.stringify(ejercicios, null, 2)};\n`;
-      await fs.writeFile(filePath, content, 'utf-8');
+      await fs.writeFile(filePath, content, { encoding: 'utf-8', mode: 0o666 });
       res.json({ success: true });
     } catch (error) {
-      console.error('Error saving mejorar file:', error);
+      console.error('Error saving mejoras file:', error);
       res.status(500).json({ error: 'Failed to save file' });
     }
   });


### PR DESCRIPTION
## Summary
- Save improved exercises to `mejoras.js` with writeable directory
- Add `forceImprove` action and Ctrl+K shortcut to ensure file creation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:server`
- `npm run build:renderer`


------
https://chatgpt.com/codex/tasks/task_e_689bad8681788330a8889307a6e7e31f