### PR TITLE
feat: allow saving improvements

### DIFF
--- a/client/src/pages/StudyInterface.tsx
+++ b/client/src/pages/StudyInterface.tsx
@@ -145,6 +145,12 @@ export default function StudyInterface() {
           toggleImprove(currentExercise);
         }
       }
+      if (e.ctrlKey && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        if (currentExercise && !improveMarks[currentExercise.id]) {
+          toggleImprove(currentExercise);
+        }
+      }
 
     };
     document.addEventListener('keydown', handleKeyDown);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -227,8 +227,9 @@ export async function registerRoutes(app: Express): Promise<void> {
         return res.status(400).json({ error: 'Missing fields' });
       }
       const dir = join(process.cwd(), 'sube-seccion');
-      await fs.mkdir(dir, { recursive: true });
-      const filePath = join(dir, 'mejorar.js');
+      await fs.mkdir(dir, { recursive: true, mode: 0o777 });
+      await fs.chmod(dir, 0o777);
+      const filePath = join(dir, 'mejoras.js');
       let ejercicios: any[] = [];
 
       try {
@@ -243,10 +244,11 @@ export async function registerRoutes(app: Express): Promise<void> {
 
       ejercicios.push({ tema, enunciado, ejercicio });
       const content = `export const ejercicios = ${JSON.stringify(ejercicios, null, 2)};\n`;
-      await fs.writeFile(filePath, content, 'utf-8');
+      await fs.writeFile(filePath, content, { encoding: 'utf-8', mode: 0o666 });
+      await fs.chmod(filePath, 0o666);
       res.json({ success: true });
     } catch (error) {
-      console.error('Error saving mejorar file:', error);
+      console.error('Error saving mejoras file:', error);
       res.status(500).json({ error: 'Failed to save file' });
     }
   });


### PR DESCRIPTION
## Summary
- permit writing `sube-seccion` directory and `mejoras.js` file
- force `mejoras.js` creation with Ctrl+K shortcut

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689bad8681788330a8889307a6e7e31f