### PR TITLE
feat: store mejorar feedback in user folder

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -4,8 +4,6 @@ import { loadExercisesFromFiles, addExercisesFromContent, getUploadedFilenames, 
 import { callGroqAPI } from "./services/groqApi";
 import { insertResponseSchema, insertSettingsSchema } from "@shared/schema";
 import { logger } from "./logger";
-import { promises as fs } from 'fs';
-import { join } from 'path';
 
 // BKT helper functions
 function determineSectionDomain(topics: string[], exercises: any[]): string {
@@ -216,38 +214,6 @@ export async function registerRoutes(app: Express): Promise<void> {
     } catch (error) {
       console.error('Error fetching BKT domains:', error);
       res.status(500).json({ error: 'Failed to fetch BKT data' });
-    }
-  });
-
-  // Guardar ejercicios marcados para mejorar
-  app.post('/api/mejorar', async (req, res) => {
-    try {
-      const { tema, enunciado, ejercicio } = req.body;
-      if (!tema || !enunciado) {
-        return res.status(400).json({ error: 'Missing fields' });
-      }
-      const dir = join(process.cwd(), 'sube-seccion');
-      await fs.mkdir(dir, { recursive: true });
-      const filePath = join(dir, 'mejorar.js');
-      let ejercicios: any[] = [];
-
-      try {
-        const existing = await fs.readFile(filePath, 'utf-8');
-        const match = existing.match(/export const ejercicios = (\[[\s\S]*\]);?/);
-        if (match?.[1]) {
-          ejercicios = JSON.parse(match[1]);
-        }
-      } catch {
-        // file might not exist yet or couldn't be parsed
-      }
-
-      ejercicios.push({ tema, enunciado, ejercicio });
-      const content = `export const ejercicios = ${JSON.stringify(ejercicios, null, 2)};\n`;
-      await fs.writeFile(filePath, content, 'utf-8');
-      res.json({ success: true });
-    } catch (error) {
-      console.error('Error saving mejorar file:', error);
-      res.status(500).json({ error: 'Failed to save file' });
     }
   });
 


### PR DESCRIPTION
## Summary
- manage `mejorar.js` directly on the client using the File System Access API
- remove server-side endpoint and filesystem writes for `/api/mejorar`

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689bc401e1fc8330a4252fce8643824a