### PR TITLE
feat: unify folder selection

### DIFF
--- a/client/src/store/useAppStore.ts
+++ b/client/src/store/useAppStore.ts
@@ -59,7 +59,6 @@ interface AppState {
 
   // Actions
   setExercises: (exercises: Exercise[]) => void;
-  loadExercises: () => Promise<void>;               // ← NUEVO método
   setCurrentSection: (sectionId: number) => void;
   setCurrentExercise: (index: number) => void;
   setCurrentResponse: (response: string) => void;
@@ -157,6 +156,8 @@ export const useAppStore = create<AppState>()(
 
       selectWorkDir: async () => {
         const dir = await (window as any).showDirectoryPicker();
+        const perm = await (dir as any).requestPermission?.({ mode: 'readwrite' });
+        if (perm && perm !== 'granted') return;
         set({ workDir: dir });
 
         try {


### PR DESCRIPTION
## Summary
- unify directory permission for exercise imports and improvements
- save improvement list in `mejoras.js`
- streamline settings modal with a single folder selection button

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Property 'groqApiKey' does not exist on type...)*

------
https://chatgpt.com/codex/tasks/task_e_689bcad307388330b459d9164877c28b